### PR TITLE
feat: add icons to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,16 @@
   "display": "standalone",
   "background_color": "#ffffff",
   "description": "家庭奖励系统，支持云同步",
-  "icons": []
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add 192x192 and 512x512 icons to manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c567b330fc8328b60f8b67f2d5186c